### PR TITLE
Monorepo: restrict workflow triggers to a portion of the repository

### DIFF
--- a/.github/workflows/minigrep.yml
+++ b/.github/workflows/minigrep.yml
@@ -1,0 +1,23 @@
+---
+name: minigrep
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - src/minigrep/*
+  pull_request:
+    paths:
+      - src/minigrep/*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    working-directory: src/minigrep
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/minigrep.yml
+++ b/.github/workflows/minigrep.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build
         working-directory: src/minigrep
-        run: cargo build --verbose
+        run: cargo build --verbose --color always
       - name: Run tests
         working-directory: src/minigrep
-        run: cargo test --verbose
+        run: cargo test --verbose --color always

--- a/.github/workflows/minigrep.yml
+++ b/.github/workflows/minigrep.yml
@@ -14,10 +14,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    working-directory: src/minigrep
     steps:
       - uses: actions/checkout@v1
       - name: Build
+        working-directory: src/minigrep
         run: cargo build --verbose
       - name: Run tests
+        working-directory: src/minigrep
         run: cargo test --verbose

--- a/src/minigrep/Cargo.toml
+++ b/src/minigrep/Cargo.toml
@@ -2,5 +2,6 @@
 name = "minigrep"
 version = "0.1.0"
 authors = ["Aaron Bull Schaefer <aaron@elasticdog.com>"]
+edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This restricts the branches so it only builds on push for the master branch and also for pull requests. I don't think opening this PR will trigger the check, until I change something under the project code.