### PR TITLE
Scheduled workflows only run on the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
   don't expire until an hour after creation. I was able to use a token to post a
   status on the [initial commit][]. Just something to keep in mind.
 
-- There are some documented [Workflow Limitations][].
+- There are some documented [Workflow Limitations][]...although those seem to be
+  for the previous HCL-based actions and might not be 100% applicable anymore.
+
+- Scheduled workflows run on the latest commit on the default branch.
 
 [initial commit]:
   https://github.com/elasticdog/actions-sandbox/commit/057541729acfb981b38a2034edf8ecea0b0ef7ea
@@ -19,10 +22,3 @@
 ### Can you delete the build logs for an individual run?
 
 I haven't seen a way to do this in the UI or from any of the checks/status APIs.
-
-### Are scheduled jobs only available to run from the master branch?
-
-It didn't seem like the stale issue check was running from
-https://github.com/elasticdog/actions-sandbox/pull/8 until I merged it into the
-`master` branch. We'll have to see if that's a known limitation, a config I may
-have missed, or something else.


### PR DESCRIPTION
See: https://help.github.com/en/articles/events-that-trigger-workflows#scheduled-events